### PR TITLE
Use mawk automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,12 +180,6 @@ Do not prepare scripts for the case of restore (**No Restore**, saves processing
 Zaloha2.sh --sourceDir="test_source" --backupDir="test_backup" --noRestore
 ```
 
-Instead of GNU AWK, use **MAWK**, the very fast AWK implementation based on a bytecode interpreter:
-
-```bash
-Zaloha2.sh --sourceDir="test_source" --backupDir="test_backup" --mawk
-```
-
 Produce less screen output (**No Progress Messages** from the analysis phase):
 
 ```bash
@@ -230,9 +224,8 @@ specially handle sensitive data and so on.
 
 * The option <code>--noRestore</code> switches off creation of the restore scripts.
   If you do not need the restore scripts, use this option to shorten the analysis phase.
-* The option <code>--mawk</code> instructs Zaloha2 to use MAWK instead of (usually) GNU AWK.
-  MAWK is an AWK implementation based on a bytecode interpreter and is significantly faster.
-  To utilize MAWK, it must be installed on the local system.
+* Install MAWK on the local system. MAWK is an AWK implementation based on a bytecode interpreter
+  and is significantly faster.
 
 Performance was measured on following system and data:
 
@@ -243,7 +236,7 @@ Performance was measured on following system and data:
  * Data synchronized: 110 GB, 88.000 files
  * Operating system: Linux (Fedora 30)
  * Binary utilities used by Zaloha2: GNU find, GNU sort, mawk
- * Zaloha2 options: <code>--noRestore</code> YES, <code>--mawk</code> YES, <code>--detectHLinksS</code> NO, <code>--byteByByte</code> NO
+ * Zaloha2 options: <code>--noRestore</code> YES, <code>--detectHLinksS</code> NO, <code>--byteByByte</code> NO
 
 Measured performance of the analysis phase:
  * first run: **25 seconds** (filesystem data not cached in the OS: the FINDs 2 x 12 secs, the sorts and AWKs 1 sec)
@@ -343,7 +336,7 @@ prints out the files where the SHA-256 hash equals to the SHA-256 hash in the im
 
 ## Performance tuning in the Remote Source and Remote Backup Modes
 
-* The options <code>--noRestore</code> and <code>--mawk</code> (see above) are relevant for the Remote Modes as well.
+* The option <code>--noRestore</code> and local installed MAWK (see above) are relevant for the Remote Modes as well.
 * The option <code>--findParallel</code> instructs Zaloha2 to run the FIND scans of the source and backup directories in parallel.
   As these scans run on different hosts, this will further save time.
 * Last, SCP can be tuned for higher speed by choosing suitable ciphers and compression levels. See SCP documentation for details.

--- a/Zaloha2.sh
+++ b/Zaloha2.sh
@@ -725,15 +725,6 @@ Zaloha2.sh --sourceDir=<sourceDir> --backupDir=<backupDir> [ other options ... ]
 --color         ... use color highlighting (can be used on terminals which
                     support ANSI escape codes)
 
---mawk          ... use mawk, the very fast AWK implementation based on a
-                    bytecode interpreter. Without this option, awk is used,
-                    which usually maps to GNU awk (but not always).
-                    (Note: If you know that awk on your system maps to mawk,
-                     use this option to make the mawk usage explicit, as this
-                     option also turns off mawk's i/o buffering on places where
-                     progress of commands is displayed, i.e. on places where
-                     i/o buffering causes confusion and is unwanted).
-
 --lTest         ... (do not use in real operations) support for lint-testing
                     of AWK programs
 
@@ -2146,7 +2137,6 @@ noR860Hdr=0
 noR870Hdr=0
 noProgress=0
 color=0
-mawk=0
 lTest=0
 help=0
 
@@ -2217,7 +2207,6 @@ do
     --noR870Hdr)         opt_dupli_check ${noR870Hdr} "${tmpVal}";      noR870Hdr=1 ;;
     --noProgress)        opt_dupli_check ${noProgress} "${tmpVal}";     noProgress=1 ;;
     --color)             opt_dupli_check ${color} "${tmpVal}";          color=1 ;;
-    --mawk)              opt_dupli_check ${mawk} "${tmpVal}";           mawk=1 ;;
     --lTest)             opt_dupli_check ${lTest} "${tmpVal}";          lTest=1 ;;
     --help)              opt_dupli_check ${help} "${tmpVal}";           help=1 ;;
     *) error_exit "Unknown option ${tmpVal//${CNTRLPATTERN}/${TRIPLETC}}, get help via Zaloha2.sh --help" ;;
@@ -2308,15 +2297,19 @@ if [ ${cpRestoreOptPassed} -eq 0 ]; then
 fi
 cpRestoreOptAwk="${cpRestoreOpt//${BSLASHPATTERN}/${TRIPLETB}}"
 
-if [ ${mawk} -eq 1 ]; then
-  awk='mawk'
-  awkNoBuf='mawk -W interactive'
-elif [ ${lTest} -eq 1 ]; then
-  awk='awk -Lfatal'
-  awkNoBuf='awk -Lfatal'
+awk="$(command -v mawk)" || true
+if [ -n "${awk}" ]; then
+  awkNoBuf="${awk} -W interactive"
 else
-  awk='awk'
-  awkNoBuf='awk'
+  awk="$(command -v awk)" || true
+  if [ -z "${awk}" ]; then
+    error_exit "No 'awk' program found"
+  fi
+  awkNoBuf="${awk} -Lfatal"
+fi
+
+if [ ${lTest} -eq 1 ]; then
+  awk="${awkNoBuf}"
 fi
 
 ###########################################################
@@ -2786,7 +2779,6 @@ ${TRIPLET}${FSTAB}noR860Hdr${FSTAB}${noR860Hdr}${FSTAB}${TRIPLET}
 ${TRIPLET}${FSTAB}noR870Hdr${FSTAB}${noR870Hdr}${FSTAB}${TRIPLET}
 ${TRIPLET}${FSTAB}noProgress${FSTAB}${noProgress}${FSTAB}${TRIPLET}
 ${TRIPLET}${FSTAB}color${FSTAB}${color}${FSTAB}${TRIPLET}
-${TRIPLET}${FSTAB}mawk${FSTAB}${mawk}${FSTAB}${TRIPLET}
 ${TRIPLET}${FSTAB}lTest${FSTAB}${lTest}${FSTAB}${TRIPLET}
 ${TRIPLET}${FSTAB}findLastRunOpsFinalAwk${FSTAB}${findLastRunOpsFinalAwk}${FSTAB}${TRIPLET}
 ${TRIPLET}${FSTAB}findSourceOpsFinalAwk${FSTAB}${findSourceOpsFinalAwk}${FSTAB}${TRIPLET}


### PR DESCRIPTION
- No need for extra option
- Exit with error if no [m]awk was found
- Fix ignored --lTest option when --mawk was used too (At least if the option is intended to run every awk as awkNoBuf command)

Hi Fitus, sorry for the noise!

The drawback of this patch is that you can't then no longer force to use the one or the or the other [m]awk program. But from a user few is the advandtage that you don't have to change your sripts if you like to improve the performance by using mawk.

- Using `command -v ...` resp. the full path of [m]awk program should be an security improvement 
- One may consider to add option _-p_ to `command -v ...` for even more security. I tried this with awk only and it works here
- Not updated _DOCUMENTATION.md_ (I guess you auto-generate this file)